### PR TITLE
additional diagnostics plus option for oxy sens of fsed_nit

### DIFF
--- a/src/aed_nitrogen.F90
+++ b/src/aed_nitrogen.F90
@@ -620,7 +620,6 @@ SUBROUTINE aed_calculate_benthic_nitrogen(data,column,layer_idx)
    AED_REAL :: amm_flux, nit_flux, n2o_flux, no2_flux
    AED_REAL :: Fsed_amm, Fsed_nit, Fsed_n2o, Fsed_no2
    AED_REAL :: fTa, fTo, fNO3
-   AED_REAL :: Kdenitnit
    
    AED_REAL,PARAMETER :: Kno3 = 5.0      !Denit NO3 half-sat
 !

--- a/src/aed_nitrogen.F90
+++ b/src/aed_nitrogen.F90
@@ -619,7 +619,10 @@ SUBROUTINE aed_calculate_benthic_nitrogen(data,column,layer_idx)
    ! Temporary variables
    AED_REAL :: amm_flux, nit_flux, n2o_flux, no2_flux
    AED_REAL :: Fsed_amm, Fsed_nit, Fsed_n2o, Fsed_no2
-   AED_REAL :: fTa, fTo
+   AED_REAL :: fTa, fTo, fNO3
+   AED_REAL :: Kdenitnit
+   
+   AED_REAL,PARAMETER :: Kno3 = 5.0      !Denit NO3 half-sat
 !
 !------------------------------------------------------------------------------+
 !BEGIN
@@ -629,6 +632,7 @@ SUBROUTINE aed_calculate_benthic_nitrogen(data,column,layer_idx)
    !-----------------------------------------------
    ! Retrieve local environmental conditions for this bottom water layer.
    temp = _STATE_VAR_(data%id_temp) ! local temperature
+
 
    !-----------------------------------------------
    ! Set the maximum flux (@20C) to use in this cell, either constant or linked
@@ -655,7 +659,13 @@ SUBROUTINE aed_calculate_benthic_nitrogen(data,column,layer_idx)
       if(data%Fsed_nit_model == 1) THEN
          nit_flux = Fsed_nit *           oxy/(data%Ksed_nit+oxy) * fTo
       ELSE
-         nit_flux = Fsed_nit * data%Ksed_nit/(data%Ksed_nit+oxy) * fTo    
+         nit = _STATE_VAR_(data%id_nox)  
+         IF(Kno3==zero_)THEN
+           fNO3 = one_
+         ELSE
+           fNO3 = nit/(Kno3+nit)
+         ENDIF
+         nit_flux = Fsed_nit * data%Ksed_nit/(data%Ksed_nit+oxy) * fTo * fNO3 
       ENDIF
 
       IF( data%simN2O>0 ) n2o_flux = Fsed_n2o * data%Ksed_n2o/(data%Ksed_n2o+oxy) * fTa

--- a/src/aed_organic_matter.F90
+++ b/src/aed_organic_matter.F90
@@ -93,6 +93,7 @@ MODULE aed_organic_matter
       INTEGER  :: id_sed_pop, id_sed_dop
       INTEGER  :: id_sed_poc, id_sed_doc
       INTEGER  :: id_bod, id_cdom
+      INTEGER  :: id_docr_miner, id_donr_miner, id_dopr_miner
       INTEGER  :: id_pom_vvel, id_cpom_vvel
       INTEGER  :: id_l_resus, id_denit, id_anaerobic
 
@@ -518,10 +519,24 @@ SUBROUTINE aed_define_organic_matter(data, namlst)
    ! Register diagnostic variables
    data%id_cdom = aed_define_diag_variable('CDOM','/m',  'Chromophoric DOM (CDOM)')
 
-   data%id_sed_poc = 0   ; data%id_sed_doc = 0   ; data%id_sed_pon = 0    ; data%id_sed_don = 0
-   data%id_sed_pop = 0   ; data%id_sed_dop = 0   ; data%id_poc_miner = 0  ; data%id_doc_miner = 0
-   data%id_pon_miner = 0 ; data%id_don_miner = 0 ; data%id_pop_miner = 0  ; data%id_dop_miner = 0
-   data%id_denit = 0     ; data%id_bod = 0       ; data%id_photolysis = 0
+   data%id_sed_poc = 0
+   data%id_sed_doc = 0
+   data%id_sed_pon = 0
+   data%id_sed_don = 0
+   data%id_sed_pop = 0
+   data%id_sed_dop = 0
+   data%id_poc_miner = 0
+   data%id_doc_miner = 0
+   data%id_pon_miner = 0
+   data%id_don_miner = 0
+   data%id_pop_miner = 0
+   data%id_dop_miner = 0
+   data%id_denit = 0
+   data%id_bod = 0
+   data%id_photolysis = 0
+   data%id_docr_miner = 0
+   data%id_donr_miner = 0
+   data%id_dopr_miner = 0
 
    IF (extra_diag) THEN
      data%id_sed_poc = aed_define_sheet_diag_variable('sed_poc','mmol/m**2/d',  'Net POC sediment flux')
@@ -538,6 +553,13 @@ SUBROUTINE aed_define_organic_matter(data, namlst)
      data%id_dop_miner = aed_define_diag_variable('dop_miner','mmol/m**3/d','DOP mineralisation')
      data%id_anaerobic = aed_define_diag_variable('anaerobic','mmol/m**3/d','anaerobic metabolism')
      data%id_denit = aed_define_diag_variable('denit','mmol/m**3/d','denitrification')
+     
+     
+    IF (simRPools) THEN
+        data%id_docr_miner = aed_define_diag_variable('docr_miner','mmol/m**3/d','DOCR mineralisation')
+        data%id_donr_miner = aed_define_diag_variable('donr_miner','mmol/m**3/d','DONR mineralisation')
+        data%id_dopr_miner = aed_define_diag_variable('dopr_miner','mmol/m**3/d','DOPR mineralisation')
+    ENDIF
 
      data%id_bod = aed_define_diag_variable('BOD5','mg O2/L',  'Biochemical Oxygen Demand (BOD)')
      IF ( simphotolysis .and. simRpools  ) data%id_photolysis = &
@@ -897,6 +919,12 @@ SUBROUTINE aed_calculate_organic_matter(data,column,layer_idx)
      _DIAG_VAR_(data%id_doc_miner) = doc_mineralisation*secs_per_day
      _DIAG_VAR_(data%id_don_miner) = don_mineralisation*secs_per_day
      _DIAG_VAR_(data%id_dop_miner) = dop_mineralisation*secs_per_day
+     
+     IF ( data%simRPools ) THEN
+       _DIAG_VAR_(data%id_docr_miner) = docr_mineralisation*secs_per_day
+       _DIAG_VAR_(data%id_donr_miner) = donr_mineralisation*secs_per_day
+       _DIAG_VAR_(data%id_dopr_miner) = dopr_mineralisation*secs_per_day
+     ENDIF
 
      ! BOD5 is computed as the amount of oxygen consumed over a 5-day period (mgO2/L)
      _DIAG_VAR_(data%id_bod) = 32./12.*(doc_mineralisation*secs_per_day*12./1e3)*5.0


### PR DESCRIPTION
Added an option to the nitrogen namelist (Fsed_nit_model) where the user can chose to have Fsed_nit increase or decrease with oxygen concentration.  It default to Fsed_nit_model = 1, which is the original behavior of the module.  

Added extra diagnostics that output the mineralization rates of docr, donr, and dopr.  This are included if extra_diag = TRUE and simRPools = TRUE