### PR TITLE
patch_csv_close

### DIFF
--- a/src/aed_csv_reader.F90
+++ b/src/aed_csv_reader.F90
@@ -616,7 +616,7 @@ LOGICAL FUNCTION aed_csv_close(unit)
 !BEGIN
    aedr => units(unit)%p
    aed_csv_close = end_parse(aedr)
-   DEALLOCATE(aedr)
+   IF (ASSOCIATED(aedr)) DEALLOCATE(aedr)
    NULLIFY(aedr)
    units(unit)%p => aedr
 END FUNCTION aed_csv_close


### PR DESCRIPTION
When compiled with ifort version 2021.3.0 we were experiencing a fortran severe error when pointer was not associated. Propose adding "IF (associated(aedr))".