### PR TITLE
Changes to diagnostic variables in order and number

### DIFF
--- a/src/aed_organic_matter.F90
+++ b/src/aed_organic_matter.F90
@@ -648,7 +648,8 @@ SUBROUTINE aed_define_organic_matter(data, namlst)
        aed_define_diag_variable('photolysis','mmol C/m3/d',  'photolysis rate of breakdown of DOC')
 
      data%id_pom_vvel  = aed_define_diag_variable('pom_vvel','m/d','POM vertical velocity')
-     data%id_cpom_vvel = aed_define_diag_variable('cpom_vvel','m/d','CPOM vertical velocity')
+     
+     IF (simRpools) data%id_cpom_vvel = aed_define_diag_variable('cpom_vvel','m/d','CPOM vertical velocity')
 
    ENDIF
 

--- a/src/aed_phytoplankton.F90
+++ b/src/aed_phytoplankton.F90
@@ -72,7 +72,8 @@ MODULE aed_phytoplankton
       INTEGER,ALLOCATABLE :: id_NtoP(:)
       INTEGER,ALLOCATABLE :: id_vvel(:)
       INTEGER,ALLOCATABLE :: id_fT(:), id_fI(:), id_fNit(:), &
-                             id_fPho(:), id_fSil(:), id_fSal(:)
+                             id_fPho(:), id_fSil(:), id_fSal(:), &
+                             id_PhyCUP(:), id_PhyNCP(:), id_PhySed(:)
       INTEGER :: id_Pexctarget,id_Pmorttarget,id_Pupttarget(1:2)
       INTEGER :: id_Nexctarget,id_Nmorttarget,id_Nupttarget(1:4)
       INTEGER :: id_Cexctarget,id_Cmorttarget,id_Cupttarget
@@ -269,6 +270,9 @@ SUBROUTINE aed_phytoplankton_load_params(data, dbase, count, list, settling, res
        ALLOCATE(data%id_fSil(count)) ; data%id_fSil(:) = 0
        ALLOCATE(data%id_fSal(count)) ; data%id_fSal(:) = 0
        ALLOCATE(data%id_vvel(count)) ; data%id_vvel(:) = 0
+       ALLOCATE(data%id_PhyCUP(count)) ; data%id_PhyCUP(:) = 0
+       ALLOCATE(data%id_PhyNCP(count)) ; data%id_PhyNCP(:) = 0
+       ALLOCATE(data%id_PhySed(count)) ; data%id_PhySed(:) = 0
     ENDIF
 
     DO i=1,count
@@ -400,6 +404,9 @@ SUBROUTINE aed_phytoplankton_load_params(data, dbase, count, list, settling, res
           data%id_fSil(i) = aed_define_diag_variable( TRIM(data%phytos(i)%p_name)//'_fSil', '-', 'fSil (0-1)')
           data%id_fT(i)   = aed_define_diag_variable( TRIM(data%phytos(i)%p_name)//'_fT', '-', 'fT (>0)')
           data%id_fSal(i) = aed_define_diag_variable( TRIM(data%phytos(i)%p_name)//'_fSal', '-', 'fSal (>1)')
+          data%id_PhyCUP(i) = aed_define_diag_variable( TRIM(data%phytos(i)%p_name)//'_GPP', 'mmol/m**3/d', 'group primary production')
+          data%id_PhyNCP(i) = aed_define_diag_variable( TRIM(data%phytos(i)%p_name)//'_NCP', 'mmol/m**3/d', 'group net production')
+          data%id_PhySed(i) = aed_define_diag_variable( TRIM(data%phytos(i)%p_name)//'_SED', 'mmol/m**2/d', 'group sedimentation')
           ! Register vertical velocity diagnostic, where relevant
           IF (data%phytos(i)%settling == _MOB_STOKES_ .OR. &
                                    data%phytos(i)%settling == _MOB_MOTILE_) THEN
@@ -902,6 +909,8 @@ SUBROUTINE aed_calculate_phytoplankton(data,column,layer_idx)
          _DIAG_VAR_(data%id_fPho(phy_i)) =  fPho
          _DIAG_VAR_(data%id_fSil(phy_i)) =  fSil
          _DIAG_VAR_(data%id_fSal(phy_i)) =  fSal
+         _DIAG_VAR_(data%id_PhyCUP(phy_i)) =  cuptake(phy_i) * secs_per_day !BMT
+         _DIAG_VAR_(data%id_PhyNCP(phy_i)) =  (cuptake(phy_i) - respiration(phy_i)*data%phytos(phy_i)%k_fres*phy) * secs_per_day !BMT
       ENDIF
    END DO
 
@@ -1300,6 +1309,7 @@ SUBROUTINE aed_mobility_phytoplankton(data,column,layer_idx,mobility)
       ! set sedimentation flux (mmmol/m2) for later use/reporting
       _DIAG_VAR_(data%id_Psed_phy) =   &
               _DIAG_VAR_(data%id_Psed_phy) + vvel*_STATE_VAR_(data%id_p(phy_i))
+      _DIAG_VAR_(data%id_PhySed(phy_i)) = vvel*_STATE_VAR_(data%id_p(phy_i))
     ENDDO
 END SUBROUTINE aed_mobility_phytoplankton
 !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/src/aed_sedflux.F90
+++ b/src/aed_sedflux.F90
@@ -454,6 +454,15 @@ SUBROUTINE aed_define_sedflux(data, namlst)
    IF ( Fsed_oxy .GT. MISVAL ) &
       data%id_Fsed_oxy = aed_define_sheet_diag_variable('Fsed_oxy','mmol/m**2',   &
                                           'flux rate of oxygen across the swi')
+   IF ( Fsed_dic .GT. MISVAL ) &
+      data%id_Fsed_dic = aed_define_sheet_diag_variable('Fsed_dic','mmol/m**2',   &
+                                          'flux rate of dic across the swi')
+   IF ( Fsed_ch4 .GT. MISVAL ) &
+      data%id_Fsed_ch4 = aed_define_sheet_diag_variable('Fsed_ch4','mmol/m**2',   &
+                                          'flux rate of ch4 across the swi')
+   IF ( Fsed_ch4_ebb .GT. MISVAL ) &
+      data%id_Fsed_ch4_ebb = aed_define_sheet_diag_variable('Fsed_ch4_ebb','mmol/m**2',   &
+                                          'flux rate of ch4 bubbles across the swi')
    IF ( Fsed_rsi .GT. MISVAL ) &
       data%id_Fsed_rsi = aed_define_sheet_diag_variable('Fsed_rsi','mmol/m**2',   &
                                           'flux rate of rsi across the swi')
@@ -469,6 +478,12 @@ SUBROUTINE aed_define_sedflux(data, namlst)
    IF ( Fsed_frp .GT. MISVAL ) &
       data%id_Fsed_frp = aed_define_sheet_diag_variable('Fsed_frp','mmol/m**2',   &
                                           'flux rate of frp across the swi')
+   IF ( Fsed_poc .GT. MISVAL ) &
+      data%id_Fsed_poc = aed_define_sheet_diag_variable('Fsed_poc','mmol/m**2',   &
+                                          'sedimentation rate of poc')
+   IF ( Fsed_doc .GT. MISVAL ) &
+      data%id_Fsed_doc = aed_define_sheet_diag_variable('Fsed_doc','mmol/m**2',   &
+                                          'flux rate of doc across the swi')
    IF ( Fsed_pon .GT. MISVAL ) &
       data%id_Fsed_pon = aed_define_sheet_diag_variable('Fsed_pon','mmol/m**2',   &
                                           'sedimentation rate of pon')
@@ -481,21 +496,6 @@ SUBROUTINE aed_define_sedflux(data, namlst)
    IF ( Fsed_dop .GT. MISVAL ) &
       data%id_Fsed_dop = aed_define_sheet_diag_variable('Fsed_dop','mmol/m**2',   &
                                           'flux rate of dop across the swi')
-   IF ( Fsed_poc .GT. MISVAL ) &
-      data%id_Fsed_poc = aed_define_sheet_diag_variable('Fsed_poc','mmol/m**2',   &
-                                          'sedimentation rate of poc')
-   IF ( Fsed_doc .GT. MISVAL ) &
-      data%id_Fsed_doc = aed_define_sheet_diag_variable('Fsed_doc','mmol/m**2',   &
-                                          'flux rate of doc across the swi')
-   IF ( Fsed_dic .GT. MISVAL ) &
-      data%id_Fsed_dic = aed_define_sheet_diag_variable('Fsed_dic','mmol/m**2',   &
-                                          'flux rate of dic across the swi')
-   IF ( Fsed_ch4 .GT. MISVAL ) &
-      data%id_Fsed_ch4 = aed_define_sheet_diag_variable('Fsed_ch4','mmol/m**2',   &
-                                          'flux rate of ch4 across the swi')
-   IF ( Fsed_ch4_ebb .GT. MISVAL ) &
-      data%id_Fsed_ch4_ebb = aed_define_sheet_diag_variable('Fsed_ch4_ebb','mmol/m**2',   &
-                                          'flux rate of ch4 bubbles across the swi')
    IF ( Fsed_feii .GT. MISVAL ) &
       data%id_Fsed_feii = aed_define_sheet_diag_variable('Fsed_feii','mmol/m**2', &
                                           'flux rate of feii across the swi')


### PR DESCRIPTION
Hi Casper and Matt

Happy new year! 

This is a request for three overall changes to the pelagic diagnostic variable calcs/outputs in libaed-water. Hopefully they are pretty simple and OK - I know that changes to variables/diag variables can cause angst though, so am happy to chat.

The request is three fold (in the order shown in the code below):

1. aed_organic_matter

- Only creating the 'cpom_vvel' diag when cpom (refractories) are simulated.

2. aed_phytoplankton

- Creating three new diagnostics that are primary productivity, net primary productivity and sedimentation for each phyto group. These are only included as summed diag variables at present I think, which means users can't drill down into the detail of each phyto group's growth behaviour. Having these extra diagnostics would really help calibration I think, and complement the summed diagnostic nicely.

3. aed_sedflux

- The fsed sheet diagnostics are not created in the same order as variables (or the other parallel non-sheet diagnostics) so this is a request to change that order here to be consistent from the user's point of view and that of other variables. It moves carbon diags to between DO and silicate, and rearranges the suite of organic fsed sheet diags to be the same order used elsewhere: POC, DOC, PON, DON, POP, DOP

Thanks

MB
