### PR TITLE
Changes to Xon

### DIFF
--- a/src/aed_nitrogen.F90
+++ b/src/aed_nitrogen.F90
@@ -368,7 +368,7 @@ SUBROUTINE aed_calculate_nitrogen(data,column,layer_idx)
                          nitrousation, denitrousation, &
                          ammonium_oxidation, ammonium_release
 
-   AED_REAL,PARAMETER :: Xon  =  3.0     !ratio of O2 to N utilised during nitrification
+   AED_REAL,PARAMETER :: Xon  =  2.0     !ratio of O2 to N utilised during nitrification
    AED_REAL,PARAMETER :: Knev =  3.0     !Nevison nitrification O2 threshold
    AED_REAL,PARAMETER :: aa   =  0.26    !Nevison nitrification parameter
    AED_REAL,PARAMETER :: bb   = -0.0006  !Nevison nitrification parameter


### PR DESCRIPTION
Hi Matt and Casper

Matt and I talked about this a while ago. It'd be nice to confirm the stoichiometry of oxygen consumption via inorganic N nitrification please. It is currently at 3.0, but this requestis that it be 2.0, based on the attached. I am not sure (and don't mind) which value of Xon is correct - just need to confirm either way so I can write up the WQM manual process equations and move on please.

Ta

MB

![image](https://user-images.githubusercontent.com/95277064/148133300-8fffd21d-bdd2-463a-9b4f-bb0078ab56e6.png)
