### PR TITLE
Changes to N-fixing penalty function and salinity tolerance

### DIFF
--- a/src/aed_phytoplankton.F90
+++ b/src/aed_phytoplankton.F90
@@ -836,7 +836,7 @@ SUBROUTINE aed_calculate_phytoplankton(data,column,layer_idx)
       IF (data%phytos(phy_i)%simNFixation /= 0) THEN
          ! Nitrogen fixing species, and the growth rate to  must be reduced
          ! to compensate for the increased metabolic cost of this process
-         primprod(phy_i) = primprod(phy_i) * (data%phytos(phy_i)%k_nfix + &
+         primprod(phy_i) = primprod(phy_i) * ( &
                            (1.0-a_nfix(phy_i))*(1.0-data%phytos(phy_i)%k_nfix))
       ENDIF
 
@@ -846,7 +846,7 @@ SUBROUTINE aed_calculate_phytoplankton(data,column,layer_idx)
 
       ! Salinity stress effect on respiration (or growth)
       fSal =  phyto_salinity(data%phytos,phy_i,salinity)
-      IF( data%phytos(phy_i)%salTol >= 4) THEN
+      IF( data%phytos(phy_i)%salTol <= 4) THEN
         primprod(phy_i) = primprod(phy_i) * fSal   ! growth limtation rather than mortality enhancement
       ELSE
         respiration(phy_i) = respiration(phy_i) * fSal


### PR DESCRIPTION
Hi Matt and Casper

A couple of requests on phyto routines in this one:

- Matt and I discussed the metabolic penalty function for nfixers. Although I understand the double engine effect, I think the requested form of the function is what Matt suggested it should be when we chatted
- The logic salTol >=4 means that all except one fSal is applied to respiration. This does not seem to match up with the shapes of the fSal functions. If this was the case, then most of these functions will have unlimited growth, and respiration occurring only in small salinity bands - which without limitation by nutrients/temperature etc can lead to large phyto growth. The suggested change may also not be correct - but review of the logic is appreciated please

Both of these are just suggestions - I just need to know the reasoning behind whatever is correct so that I can finish writing the WQM manual and close this issue out please.

Ta

MB