### PR TITLE
Changes to screen messaging

### DIFF
--- a/src/aed_oxygen.F90
+++ b/src/aed_oxygen.F90
@@ -202,10 +202,12 @@ SUBROUTINE aed_define_oxygen(data, namlst)
 !
 !-------------------------------------------------------------------------------
 !BEGIN
+   ! somehow only print and STOP screen echoes if AED is being used
    print *,"        aed_oxygen initialization"
 
    ! Read the namelist
    read(namlst,nml=aed_oxygen,iostat=status)
+   ! somehow only print and STOP screen echoes if AED is being used
    IF (status /= 0) STOP 'Error reading namelist aed_oxygen'
 
    ! Store parameter values in the modules own derived type


### PR DESCRIPTION
Hi Matt and Casper

This is a request to somehow suppress AED screen messaging if the TUFLOW WQM is used. Or, only allow screen messaging when AED is used. Although the screen commentary for AED is useful (I like the new additions!) it is confusing for FV WQM users because they get two sets of commentary - one from the WQM and one from AED (and the AED nomenclature is not known to the WQM users anyway).

I have used aed_oxygen as an example in this pull request, but obviously the commentary is throughout the AED code base.

Is there perhaps some compiler directives that can be set up to switch these screen prints off (or on)?

Happy to chat.

MB