### PR TITLE
Suggested fixes for atmospheric N and P deposition diagnostics

### DIFF
--- a/src/aed_nitrogen.F90
+++ b/src/aed_nitrogen.F90
@@ -605,8 +605,7 @@ SUBROUTINE aed_calculate_surface_nitrogen(data,column,layer_idx)
     !-----------------------------------------------
     ! Also store deposition across the atm/water interface as a
     ! diagnostic variable (mmmol/m2/day).
-    _DIAG_VAR_S_(data%id_atm_dep) = _DIAG_VAR_S_(data%id_atm_dep) &
-        + (_FLUX_VAR_T_(data%id_nox) + _FLUX_VAR_T_(data%id_amm)) * secs_per_day
+    _DIAG_VAR_S_(data%id_atm_dep) = (_FLUX_VAR_T_(data%id_nox) + _FLUX_VAR_T_(data%id_amm)) * secs_per_day
   ENDIF
 
 END SUBROUTINE aed_calculate_surface_nitrogen

--- a/src/aed_phosphorus.F90
+++ b/src/aed_phosphorus.F90
@@ -370,9 +370,13 @@ SUBROUTINE aed_calculate_surface_phosphorus(data,column,layer_idx)
     !-----------------------------------------------
     ! Also store deposition across the atm/water interface as a
     ! diagnostic variable (mmmol/m2/day).
-   IF (data%simPO4Adsorption) & !# id_frpads is not set unless simPO4Adsorption is true
-    _DIAG_VAR_S_(data%id_atm_dep) = _DIAG_VAR_S_(data%id_atm_dep) &
-        + (_FLUX_VAR_T_(data%id_frp) + _FLUX_VAR_T_(data%id_frpads)) * secs_per_day
+   IF (data%simPO4Adsorption) THEN !# id_frpads is not set unless simPO4Adsorption is true
+        _DIAG_VAR_S_(data%id_atm_dep) = (_FLUX_VAR_T_(data%id_frp) + _FLUX_VAR_T_(data%id_frpads)) * secs_per_day
+   ELSE
+        _DIAG_VAR_S_(data%id_atm_dep) = _FLUX_VAR_T_(data%id_frp) * secs_per_day
+   END IF
+       
+   
   ENDIF
 
 END SUBROUTINE aed_calculate_surface_phosphorus


### PR DESCRIPTION
Hi Matt and Casper

This pull request is around atmospheric N and P deposition diags. I have come across it because I am trying to do mass balance calcs for the WQM manual.  I think there are two things worth looking at:

1) In both the N and P atm deposition sheet diags, the update to the _DIAG_VAR_S_(data%id_atm_dep) array adds the new atmospheric fluxes at each timestep (which is fine), but also adds itself. I think this means that the atmospheric sheet diags report cumulative atmospheric deposition, (which is what I am seeing) which is not consistent with the other sheet diags such as sed fluxes. My suggested fix is to just have the _DIAG_VAR_S_(data%id_atm_dep) bet set to the FLUX_VAR_T's and nothing else (for both N and P). I don't think this affects the actual fluxes (the N is added), but the diags are not consistent with the fluxes so it is confusing to reconcile both.

2) The P atmospheric deposition _DIAG_VAR_S_ only adds wet deposition fluxes to the sheet if adsorption is simulated. This means that a user not simulating adsorption gets zeros for the atmospheric flux of P in the diagnostic, even if they specify rainfall and TP concentrations. I think the actual flux is fine (the P gets added) but the diagnostic doesn't reflect this flux (and my mass balances are broken!) and it is again confusing.

Thanks!!

MB