### PR TITLE
Xon equal to 2 or 3?

### DIFF
--- a/src/aed_nitrogen.F90
+++ b/src/aed_nitrogen.F90
@@ -368,7 +368,7 @@ SUBROUTINE aed_calculate_nitrogen(data,column,layer_idx)
                          nitrousation, denitrousation, &
                          ammonium_oxidation, ammonium_release
 
-   AED_REAL,PARAMETER :: Xon  =  3.0     !ratio of O2 to N utilised during nitrification
+   AED_REAL,PARAMETER :: Xon  =  2.0     !ratio of O2 to N utilised during nitrification
    AED_REAL,PARAMETER :: Knev =  3.0     !Nevison nitrification O2 threshold
    AED_REAL,PARAMETER :: aa   =  0.26    !Nevison nitrification parameter
    AED_REAL,PARAMETER :: bb   = -0.0006  !Nevison nitrification parameter


### PR DESCRIPTION
Hi Matt and Casper
Me again. This is a small issue we talked about a while ago Matt - the consumption of O2 via nitrification of ammonium. The ratio of moles N:O2 is Xon and is set to 3 in the library. This pull request is about whether Xon could be 2, based on the reactions below? I guess I am keen to know what the underlying reactions are so that I can write them up in the TUFLOW WQM manual correctly - not an issue for me either way, but I just need the TUFLOW manual to be correct!
Thanks
MB
![image](https://user-images.githubusercontent.com/95277064/150329507-b4ec0968-4cac-43ae-8ef7-3bed19841f0d.png)

