### PR TITLE
id_Psed_phy and id_PhySed units

### DIFF
--- a/src/aed_phytoplankton.F90
+++ b/src/aed_phytoplankton.F90
@@ -1308,8 +1308,8 @@ SUBROUTINE aed_mobility_phytoplankton(data,column,layer_idx,mobility)
               _DIAG_VAR_(data%id_vvel(phy_i)) = vvel * secs_per_day
       ! set sedimentation flux (mmmol/m2) for later use/reporting
       _DIAG_VAR_(data%id_Psed_phy) =   &
-              _DIAG_VAR_(data%id_Psed_phy) + vvel*_STATE_VAR_(data%id_p(phy_i))
-      _DIAG_VAR_(data%id_PhySed(phy_i)) = vvel*_STATE_VAR_(data%id_p(phy_i))
+              _DIAG_VAR_(data%id_Psed_phy) + vvel*_STATE_VAR_(data%id_p(phy_i)) * secs_per_day
+      _DIAG_VAR_(data%id_PhySed(phy_i)) = vvel*_STATE_VAR_(data%id_p(phy_i)) * secs_per_day
     ENDDO
 END SUBROUTINE aed_mobility_phytoplankton
 !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
Hi Matt

I noticed in my mass balance work that the units of sedimentation for phytos are mmol/m2/sec, and are reported in the group and community diagnostics as such. The other sediment related diagnostics like FSed are reported in mmol/m2/day. This is potentially confusing for users who might assume that all sediment related fluxes are reported in the same units (I did and it took me a while to work out what was going wrong!!). 

Is it possible to make the units of all sediment fluxes /m2/day, instead of a combination of /m2/s and /m2/day? I realise tat this may have impacts more broadly than I have considered (e.g. in the sediment diagenesis module perhaps) but for the majority of consulting users who will be simulating DO, inorganics, organics and phytos, this change of units between sed fluxes might be a pitfall that can be avoided.

Thanks

MB
