### PR TITLE
Suggested nfix diag

### DIFF
--- a/src/aed_bio_utils.F90
+++ b/src/aed_bio_utils.F90
@@ -279,7 +279,8 @@ SUBROUTINE phyto_internal_nitrogen(phytos,group,do_N2uptake,phy,IN,primprod,   &
    IF (phytos(group)%simDONUptake /= 0) THEN
       uptake(idon) = 0.0                   !MH to fix  (idon == 3)
    ENDIF
-   IF (phytos(group)%simNFixation /= 0 .AND. do_N2uptake) THEN
+!   IF (phytos(group)%simNFixation /= 0 .AND. do_N2uptake) THEN
+   IF (phytos(group)%simNFixation /= 0) THEN
       uptake(iN2) = a_nfix                 ! iN2 == 4
    ENDIF
 

--- a/src/aed_phytoplankton.F90
+++ b/src/aed_phytoplankton.F90
@@ -1115,7 +1115,7 @@ SUBROUTINE aed_calculate_phytoplankton(data,column,layer_idx)
    IF ( diag_level >= 10 ) _DIAG_VAR_(data%id_NPR) =  -999. !net_cuptake / ( sum(cuptake) - net_cuptake)
    _DIAG_VAR_(data%id_NUP) =  sum(-nuptake(:,1))*secs_per_day
    _DIAG_VAR_(data%id_NUP2)=  sum(-nuptake(:,2))*secs_per_day
-   _DIAG_VAR_(data%id_NUPN2)=  sum(-nuptake(:,in2))*secs_per_day
+   _DIAG_VAR_(data%id_NUPN2)=  sum(nuptake(:,in2))*secs_per_day
    _DIAG_VAR_(data%id_PUP) =  sum(-puptake)*secs_per_day
    _DIAG_VAR_(data%id_CUP) =  sum(-cuptake)*secs_per_day
 

--- a/src/aed_phytoplankton.F90
+++ b/src/aed_phytoplankton.F90
@@ -84,7 +84,7 @@ MODULE aed_phytoplankton
       INTEGER :: id_GPP, id_NCP, id_PPR, id_NPR, id_dPAR
       INTEGER :: id_TPHY, id_TCHLA, id_TIN, id_TIP
       INTEGER :: id_MPB, id_d_MPB, id_d_BPP, id_d_BCP, id_d_mpbv
-      INTEGER :: id_NUP, id_NUP2, id_PUP, id_CUP
+      INTEGER :: id_NUP, id_NUP2, id_NUPN2, id_PUP, id_CUP
 
       !# Model parameters
       INTEGER  :: num_phytos
@@ -643,6 +643,7 @@ SUBROUTINE aed_define_phytoplankton(data, namlst)
 
    data%id_NUP = aed_define_diag_variable('NUP_no3','mmol/m**3/d','nitrogen (NO3) uptake')
    data%id_NUP2= aed_define_diag_variable('NUP_nh4','mmol/m**3/d','nitrogen (NH4) uptake')
+   data%id_NUPN2= aed_define_diag_variable('NUP_n2','mmol/m**3/d','nitrogen (N2) uptake')
    data%id_PUP = aed_define_diag_variable('PUP','mmol/m**3/d','phosphorous uptake')
    data%id_CUP = aed_define_diag_variable('CUP','mmol/m**3/d','carbon uptake')
 
@@ -1114,6 +1115,7 @@ SUBROUTINE aed_calculate_phytoplankton(data,column,layer_idx)
    IF ( diag_level >= 10 ) _DIAG_VAR_(data%id_NPR) =  -999. !net_cuptake / ( sum(cuptake) - net_cuptake)
    _DIAG_VAR_(data%id_NUP) =  sum(-nuptake(:,1))*secs_per_day
    _DIAG_VAR_(data%id_NUP2)=  sum(-nuptake(:,2))*secs_per_day
+   _DIAG_VAR_(data%id_NUPN2)=  sum(-nuptake(:,in2))*secs_per_day
    _DIAG_VAR_(data%id_PUP) =  sum(-puptake)*secs_per_day
    _DIAG_VAR_(data%id_CUP) =  sum(-cuptake)*secs_per_day
 


### PR DESCRIPTION
Hi Matt

I know you mentioned that you were adding more diags, but this one would be good if it was in the mix please. It is a community phyto diag for fixed N. 

There are two parts - adding the diag (easy), but also suggesting a change that looks like it precludes the fixed N moles being recorded in position 4 of the N uptake array. The boolean flag "do_N2uptake" doesn't look to be set anywhere, or used anywhere except in writing this moles on fixed N to nuptake. It is always false so as an AND logical it stops writing to nuptake(phi,4) in bio_utils. This pull request is to suggest removing this logic and reporting the outcome to a new diag var.

Thanks
MB