### PR TITLE
Negatises anfix

### DIFF
--- a/src/aed_bio_utils.F90
+++ b/src/aed_bio_utils.F90
@@ -280,7 +280,7 @@ SUBROUTINE phyto_internal_nitrogen(phytos,group,do_N2uptake,phy,IN,primprod,   &
       uptake(idon) = 0.0                   !MH to fix  (idon == 3)
    ENDIF
    IF (phytos(group)%simNFixation /= 0 .AND. do_N2uptake) THEN
-      uptake(iN2) = a_nfix                 ! iN2 == 4
+      uptake(iN2) = -a_nfix                 ! iN2 == 4
    ENDIF
 
 


### PR DESCRIPTION
Hi Matt

I think this is what we were talking about today - nfix not conserving mass with internal nutrients simulated.  

It is down to signs of various quantities. When the flux of N is computed on the line below, nuptake(phy_i,:) is summed to get total uptake, and the sum is negatised. This is fine for amm and no3 - their uptakes are negative quantities, so summing them and negatising the sum provides a positive uptake quantity. 

Nitrogen fixing uptake at nuptake(phy_i,4) (anfix) however is computed as a positive uptake quantity and so adding it to the negative amm and no3 uptakes means that the terms partially cancel, and are not added up correctly: a positive anfix uptake is added to the two negative amm and no3 uptakes, and then the sum negatised.  I included the debug info on the right hand side of the screen shot below so you can see the signs of the elements of the nuptake array.

I have suggested the below fix in aed_bio_utils, that is, reporting anfix uptake as a negative quantity back to aed_phytoplankton. This way, all the summed uptakes are the same sign (negative) before the sum is negatised. This suggestion might have flow on effects elsewhere in the code though, so I am not sure. 

When I make this change in my local repo I get mass to conserve to 0.2% over a month. Without the fix the divergence was greater than 20%.

MB


![image](https://user-images.githubusercontent.com/95277064/154248694-99aced73-5a87-42d2-a660-f52df5493026.png)


Quick update: the new diagnostic below will also be affected by the sign of anfix. The sum on nuptake will be potentially cancelling rather than additive.

![image](https://user-images.githubusercontent.com/95277064/155055862-cbf368ed-7584-4d51-ba5b-569fa9cb6e76.png)



