### PR TITLE
Upper limit to internal nutrient limit functions

### DIFF
--- a/src/aed_bio_utils.F90
+++ b/src/aed_bio_utils.F90
@@ -336,6 +336,8 @@ FUNCTION phyto_fN(phytos, group, IN, din, don) RESULT(fN)
    ENDIF
 
    IF ( fN < zero_ ) fN = zero_
+   IF ( fN > 1.000 ) fN = 1.000
+      
 END FUNCTION phyto_fN
 !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -366,7 +368,8 @@ FUNCTION phyto_fP(phytos, group, IP, frp) RESULT(fP)
                           (phytos(group)%X_pmax-phytos(group)%X_pmin)
    ENDIF
 
-   IF( fP<zero_ ) fP=zero_
+   IF( fP < zero_ ) fP = zero_ 
+   IF( fP > 1.000 ) fP = 1.000 
 
 END FUNCTION phyto_fP
 !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
Hi Matt
Just some small suggestions to limit the upper bound of nutrient limit functions that are computed with internal nutrients simulated. They can be reported as greater than 1.000, which may generate user questions and increase our support load! These suggestions mirror the lower bound cap at zero_ that was already in place.
Michael