### PR TITLE
IN and IP community diag reporting

### DIFF
--- a/src/aed_phytoplankton.F90
+++ b/src/aed_phytoplankton.F90
@@ -1060,6 +1060,9 @@ SUBROUTINE aed_calculate_phytoplankton(data,column,layer_idx)
          available = MAX(zero_, INi - data%phytos(phy_i)%X_nmin*phy)
          IF ( -flux*dtlim > available  ) flux = -0.99*available/dtlim
          _FLUX_VAR_(data%id_in(phy_i)) = _FLUX_VAR_(data%id_in(phy_i)) + (flux)
+      ELSE
+         ! Assumed constant IN
+         INi = phy*data%phytos(phy_i)%X_ncon
       ENDIF
 
       !------------------------------------------------------------------------+
@@ -1072,6 +1075,9 @@ SUBROUTINE aed_calculate_phytoplankton(data,column,layer_idx)
          available = MAX(zero_, IPi - data%phytos(phy_i)%X_pmin*phy)
          IF ( -flux*dtlim > available  ) flux = -0.99*available/dtlim
          _FLUX_VAR_(data%id_ip(phy_i)) = _FLUX_VAR_(data%id_ip(phy_i)) + (flux)
+      ELSE
+         ! Assumed constant IP
+         IPi = phy*data%phytos(phy_i)%X_pcon    
       ENDIF
 
       !------------------------------------------------------------------------+


### PR DESCRIPTION
Hi Matt

This makes sure that phytoplankton community IN and IP totals are reported to be consistent with summing group equivalents, regardless of whether IN and IP are state variables. 

Without this modification, the case where two phyto groups are simulated (with the first including IN and IP and the second assuming constant X_ncon and X_pcon) has the IN and IP from the first group written twice to the IN and IP community diagnostic, so that the respective diags are just double the IN and IP of the first phyto group. This is because INi and IPi are not updated before being written to the community diagnostic, if IN and IP are not state variables. This makes the diagnostic variable hard to interpret and not able to be used in mass balance calculations.

This suggested change makes that update to INi and IPi for every phyto group regardless of whether IN and IP are simulated or not, and therefore corrects the diag output and allows for its interpretation and use in mass balance calcs.

MB