### PR TITLE
Modifies respiration diag

### DIFF
--- a/src/aed_phytoplankton.F90
+++ b/src/aed_phytoplankton.F90
@@ -1020,6 +1020,9 @@ SUBROUTINE aed_calculate_phytoplankton(data,column,layer_idx)
 
    DO phy_i=1,data%num_phytos
      IF ( diag_level >= 10 ) THEN
+          phy = _STATE_VAR_(data%id_p(phy_i))
+          IF (data%phytos(phy_i)%simINDynamics /= 0) THEN; INi = _STATE_VAR_(data%id_in(phy_i)); ELSE; INi = phy*data%phytos(phy_i)%X_ncon; END IF
+          IF (data%phytos(phy_i)%simIPDynamics /= 0) THEN; IPi = _STATE_VAR_(data%id_ip(phy_i)); ELSE; IPi = phy*data%phytos(phy_i)%X_pcon; END IF
           ! Carbon fluxes
           _DIAG_VAR_(data%id_PhyGPPc(phy_i)) =  cuptake(phy_i) * secs_per_day
           _DIAG_VAR_(data%id_PhyRSPc(phy_i)) = ( -respiration(phy_i)*data%phytos(phy_i)%k_fres*phy) * secs_per_day


### PR DESCRIPTION
Hi Matt

This is similar to https://github.com/AquaticEcoDynamics/libaed-water/pull/51.

The new respiration diags for C, N and P all use the variables "phy", "INi" and "IPi". These change with phyto group but the location of the diag writing for diags id_PhyRSPc, id_PhyRSPn and id_PhyRSPp mean that the values of phy, INi and IPi from the last phyto group were being used to compute and write these respiration diags. This meant that if simulating two phyto groups, both were recording the same respiration diag data (i.e. that of the second phyto group) because phy, INi and IPi were the values left over from the previous loop on num_phy. Mass balance calculations were affected and the diags were difficult to interpret.

This suggestion reloads the correct phyto group by phyto group values of phy, INi and IPi before calculating and recording the respiration diagnostics. I have run the revised code and this fixes the mass balance issues.

MB
