### PR TITLE
Modifies phyto N and P sedimentation

### DIFF
--- a/src/aed_phytoplankton.F90
+++ b/src/aed_phytoplankton.F90
@@ -1415,11 +1415,15 @@ SUBROUTINE aed_mobility_phytoplankton(data,column,layer_idx,mobility)
       IF(data%phytos(phy_i)%simINDynamics>0) THEN
          mobility(data%id_in(phy_i)) = vvel
          _DIAG_VAR_(data%id_PhySEDn(phy_i)) = vvel*_STATE_VAR_(data%id_in(phy_i))* secs_per_day
+      ELSE
+         _DIAG_VAR_(data%id_PhySEDn(phy_i)) = vvel*_STATE_VAR_(data%id_p(phy_i))* data%phytos(phy_i)%X_ncon* secs_per_day
       ENDIF
       ! set global mobility array for phytoplankton IP pool, and record flux
       IF(data%phytos(phy_i)%simIPDynamics>0) THEN
          mobility(data%id_ip(phy_i)) = vvel
          _DIAG_VAR_(data%id_PhySEDp(phy_i)) = vvel*_STATE_VAR_(data%id_ip(phy_i))* secs_per_day
+      ELSE
+         _DIAG_VAR_(data%id_PhySEDp(phy_i)) = vvel*_STATE_VAR_(data%id_p(phy_i))* data%phytos(phy_i)%X_pcon* secs_per_day
       ENDIF
 
        ! cumulate the community sedimentation flux (mmmol/m2/s) for later use


### PR DESCRIPTION
Hi Matt

This is similar to pull requests https://github.com/AquaticEcoDynamics/libaed-water/pull/51 and https://github.com/AquaticEcoDynamics/libaed-water/pull/52.

As it stands, the new phy sedimentation diags do not account for phyto groups that do not simulate IN and IP. This makes the phy diag settling N and P diags hard to interpret, and doesn't allow for TN and TP mass balances to hold. This suggested modification adds the IN and IP entering the sediments within phyto groups that do not simulate internal nutrients (simINDynamics and simIPDynamics = 0). I have tested the modifications and mass balance holds to within 0.015% over a month long simulation.

I have not looked at resus, but I am guessing that a similar modification might be needed for the corresponding diag calculation, otherwise the mass balance will fail. I have not included that code modification in this pull request.

MB