### PR TITLE
Anammox calculation modification

### DIFF
--- a/src/aed_nitrogen.F90
+++ b/src/aed_nitrogen.F90
@@ -493,9 +493,9 @@ SUBROUTINE aed_calculate_nitrogen(data,column,layer_idx)
 
      !-----------------------------------------------
      ! Set temporal derivatives
-     _FLUX_VAR_(data%id_amm) = _FLUX_VAR_(data%id_amm) - nitrification - anammox + dnra
+     _FLUX_VAR_(data%id_amm) = _FLUX_VAR_(data%id_amm) - nitrification - anammox * (1.0/2.32) * amm + dnra
      _FLUX_VAR_(data%id_nox) = _FLUX_VAR_(data%id_nox) &
-                             + nitrification - denitrification - anammox - dnra
+                             + nitrification - denitrification - anammox * (1.32/2.32) * nit - dnra
      IF( data%simN2O==1 ) &
        _FLUX_VAR_(data%id_n2o) = _FLUX_VAR_(data%id_n2o)  &
                              +  (denit_n2o_prod - denit_n2o_cons + nit_n2o_prod)
@@ -508,7 +508,7 @@ SUBROUTINE aed_calculate_nitrogen(data,column,layer_idx)
      ! Export diagnostic variables
      _DIAG_VAR_(data%id_nitrf)   = nitrification * secs_per_day
      _DIAG_VAR_(data%id_denit)   = denitrification * secs_per_day
-     _DIAG_VAR_(data%id_anammox) = anammox * secs_per_day
+     _DIAG_VAR_(data%id_anammox) = anammox * ((amm + 1.32 * nit)/2.32) * secs_per_day
      _DIAG_VAR_(data%id_dnra)    = dnra * secs_per_day
      IF( data%simN2O==1 ) THEN
        _DIAG_VAR_(data%id_n2op) = (denit_n2o_prod + nit_n2o_prod) * secs_per_day


### PR DESCRIPTION
Hi Matt

I think we talked about this a while ago (I had forgotten!) and agreed to leave it. Even though it (obviously) is a process that occurs under low DO conditions so is fairly rare in environmental systems,  for one reason or another there is a need now to address this if we can please. 

The issue is that the anammox rate Ranammox (whilst being calculated by a second order MM relationship) is not multiplied by amm or nit concentrations to compute a molar flux for these consumed state variables - the per second rate seems to be added to other fluxes (such as dnra) that have been computed as multiplications or relevant rates by state variable concentrations. I am unsure about this.

I have suggested the modification below, based on Qiao et al 2017's Eqn (1), which references Strous et al. 1998. Strous et al. suggest that the molar ratio of NO2 to NH4 consumption in anammox is 1.32:1.0, hence the hardwire ratios. It might be easiest just to assume 1:1 given the biological uncertainty, but I don't really know!

Michael

The Qiao reference is:
https://www.researchgate.net/publication/313412540_A_Kinetics_Study_on_Anammox_Bacteria_with_a_Disproportionate_Substrate_Concentration

The Strous reference is:
![image](https://user-images.githubusercontent.com/95277064/156108456-bb6a2b96-32e2-4069-b5d9-fae0ed6d30aa.png)

