### PR TITLE
NCS bed mass units

### DIFF
--- a/src/aed_noncohesive.F90
+++ b/src/aed_noncohesive.F90
@@ -220,7 +220,7 @@ SUBROUTINE aed_define_noncohesive(data, namlst)
      data%id_ss_vvel(i) = aed_define_diag_variable(TRIM(ncs_name)//'_vvel','m/s','vertical velocity')
 
      IF ( simSedimentMass ) THEN
-       sed_initial = data%sed_porosity * fs(i) * sed_depth * data%rho_ss(i)
+       sed_initial = data%sed_porosity * fs(i) * sed_depth * (data%rho_ss(i)*1e3)
        data%id_ss_sed(i) = aed_define_sheet_variable(TRIM(ncs_name)//'_sed',&
                                 'g/m**2','sedimented noncohesive particles', &
                                 sed_initial,minimum=zero_)


### PR DESCRIPTION
H Matt
I think the units might need looking at for the calculation of sediment bed mass in one location (the change in this pull request). It seems to be missing the *1e3 conversion factor that is needed to get rho(i) in the right units (g/m3) to have an output of g/m2. The *1e3 conversion is applied elsewhere for the same equation (e.g. lines 297, 406 and 521 - see example below). It doesn't affect what I am doing now because a file is being used to set the sed mass ICs, and the equation that does this reset does include the *1e3 factor, but it might be affecting others.
Ta
MB

![image](https://user-images.githubusercontent.com/95277064/157769824-b7903f68-10e2-4068-a28b-765110f50b69.png)
