### PR TITLE
Suggested SimDenitrification modification

### DIFF
--- a/src/aed_organic_matter.F90
+++ b/src/aed_organic_matter.F90
@@ -928,7 +928,7 @@ SUBROUTINE aed_calculate_organic_matter(data,column,layer_idx)
                                     _FLUX_VAR_(data%id_dic) + photolysis*(1.-photo_fmin)
    ENDIF
    IF (data%use_amm) THEN
-      IF( data%simDenitrification==1 ) &
+!      IF( data%simDenitrification==1 ) &
         _FLUX_VAR_(data%id_amm) = _FLUX_VAR_(data%id_amm) + (don_mineralisation)
       !IF( data%simDenitrification==2 ) & !MH needs balacing with Denit fraction
       !  _FLUX_VAR_(data%id_amm) = _FLUX_VAR_(data%id_amm) + (don_mineralisation)


### PR DESCRIPTION
Hi Matt

It may be that when SimDenitrification = 0, don_mineralisation mmol is removed from DON but not added to any other state variables. This causes mass balance issues on ammonium. Removing the single IF statement suggested in this pull request fixes this issue: denitrification is zero, but DON still mineralises to ammonium and is accounted for correctly.