### PR TITLE
Proposed fix to include dead paths in total paths sum

### DIFF
--- a/src/aed_pathogens.F90
+++ b/src/aed_pathogens.F90
@@ -526,6 +526,7 @@ SUBROUTINE aed_calculate_pathogens(data,column,layer_idx)
       IF (data%pathogens(pth_i)%coef_sett_fa > zero_) THEN
         pth_a = _STATE_VAR_(data%id_pa(pth_i))
       END IF
+      pth_d = _STATE_VAR_(data%id_pd(pth_i))
 
       growth    = zero_
       predation = zero_


### PR DESCRIPTION
pth_d is initialised at zero and then left unchanged within aed_calculate_pathogens, so the sum of alive + attached + dead paths used to compute the total paths diag was missing dead paths.