### PR TITLE
Suggests path sedimentations diags

### DIFF
--- a/src/aed_pathogens.F90
+++ b/src/aed_pathogens.F90
@@ -101,9 +101,10 @@ MODULE aed_pathogens
 
       ! Diagnostic IDs for processes
       INTEGER,ALLOCATABLE :: id_growth(:), id_mortality(:), id_sunlight(:), id_grazing(:), id_total(:)
+      INTEGER,ALLOCATABLE :: id_pth_f_sed(:), id_pth_d_sed(:) 
 
       INTEGER  :: id_oxy, id_pH,  id_doc, id_tss           ! Dependency ID
-      INTEGER  :: id_tem, id_sal                           ! Environmental IDs (3D)
+      INTEGER  :: id_tem, id_sal, id_dz                    ! Environmental IDs (3D)
       INTEGER  :: id_par, id_nir, id_uva, id_uvb           ! Environmental IDs (3D)
       INTEGER  :: id_I_0                                   ! Environmental ID (2D)
       INTEGER  :: resuspension
@@ -253,6 +254,7 @@ SUBROUTINE aed_define_pathogens(data, namlst)
    data%id_uva = aed_locate_global('uva')
    data%id_uvb = aed_locate_global('uvb')
    data%id_I_0 = aed_locate_sheet_global('par_sf')
+   data%id_dz  = aed_locate_global('layer_ht')
    IF ( resuspension > 0 ) &
       data%id_taub = aed_locate_sheet_global('taub')
 
@@ -403,6 +405,8 @@ SUBROUTINE aed_pathogens_load_params(data, dbase, count, list)
        ALLOCATE(data%id_growth(count))
        ALLOCATE(data%id_sunlight(count))
        ALLOCATE(data%id_mortality(count))
+       ALLOCATE(data%id_pth_f_sed(count))
+       ALLOCATE(data%id_pth_d_sed(count))
     ENDIF
 
     DO i=1,count
@@ -456,6 +460,8 @@ SUBROUTINE aed_pathogens_load_params(data, dbase, count, list)
           data%id_growth(i) = aed_define_diag_variable( TRIM(data%pathogens(i)%p_name)//'_g', 'orgs/m3/day', 'growth')
           data%id_sunlight(i) = aed_define_diag_variable( TRIM(data%pathogens(i)%p_name)//'_l', 'orgs/m3/day', 'sunlight')
           data%id_mortality(i) = aed_define_diag_variable( TRIM(data%pathogens(i)%p_name)//'_m', 'orgs/m3/day', 'mortality')
+          data%id_pth_f_sed(i) = aed_define_diag_variable( TRIM(data%pathogens(i)%p_name)//'_f_set', 'orgs/m3/d', 'alive sedimentation') !PRequest
+          data%id_pth_d_sed(i) = aed_define_diag_variable( TRIM(data%pathogens(i)%p_name)//'_d_set', 'orgs/m3/d', 'dead sedimentation') !PRequest
        ENDIF
    ENDDO
    DEALLOCATE(pd)
@@ -526,6 +532,7 @@ SUBROUTINE aed_calculate_pathogens(data,column,layer_idx)
       IF (data%pathogens(pth_i)%coef_sett_fa > zero_) THEN
         pth_a = _STATE_VAR_(data%id_pa(pth_i))
       END IF
+      pth_d = _STATE_VAR_(data%id_pd(pth_i)) ! BMT pull request
 
       growth    = zero_
       predation = zero_
@@ -761,16 +768,24 @@ SUBROUTINE aed_mobility_pathogens(data,column,layer_idx,mobility)
    AED_REAL,INTENT(inout) :: mobility(:)
 !
 !LOCALS
-   AED_REAL :: temp, vel
+   AED_REAL :: temp, vel, dz
    INTEGER  :: ss_i,pth_i
 !
 !-------------------------------------------------------------------------------
 !BEGIN
    temp = _STATE_VAR_(data%id_tem)
+   dz = _STATE_VAR_(data%id_dz)
+
+   _DIAG_VAR_(data%id_pth_f_sed) = zero_
+   _DIAG_VAR_(data%id_pth_d_sed) = zero_
 
    ! First set velocity for free pathogen groups
    DO pth_i=1,data%num_pathogens
       mobility(data%id_pf(pth_i)) =  data%pathogens(pth_i)%coef_sett_w_path
+      IF ( diag_level >= 10 ) THEN
+         _DIAG_VAR_(data%id_pth_f_sed(pth_i)) = (mobility(data%id_pf(pth_i))/dz) * _STATE_VAR_(data%id_pf(pth_i)) * secs_per_day        ! orgs/m3/d   !PRequest
+         _DIAG_VAR_(data%id_pth_d_sed(pth_i)) = (mobility(data%id_pd(pth_i))/dz) * _STATE_VAR_(data%id_pd(pth_i)) * secs_per_day        ! orgs/m3/d   !PRequest
+      END IF
    ENDDO
 
    ! Compute settling rate of particles


### PR DESCRIPTION
This suggests sedimentation diagnostics for alive and dead pathogens. These are direct parallels of the equivalent phyto diags, and allow a user to independently do mass balance checks on pathogens.

Previous pull requests relating to altering pathogen diagnostic units (to /day) have not been included here to avoid double up.