### PR TITLE
Units query in aed_zooplankton.F90

### DIFF
--- a/src/aed_zooplankton.F90
+++ b/src/aed_zooplankton.F90
@@ -494,20 +494,21 @@ SUBROUTINE aed_calculate_zooplankton(data,column,layer_idx)
 
       ! Get the growth rate (/ s)
       ! grazing is in units of mass consumed/mass zoops/unit time
-      grazing = data%zoops(zoop_i)%Rgrz_zoo * fGrazing_Limitation * f_T
+      grazing = data%zoops(zoop_i)%Rgrz_zoo * fGrazing_Limitation * f_T ! Units: /d
 
       ! Now determine available prey and limit grazing amount to
       ! availability of prey
       ! food is total amount of food in units of mass/unit volume/unit time
-      food = grazing * zoo
+      food = grazing * zoo ! Units: mmC/m3/d
       IF (Ctotal_prey < data%zoops(zoop_i)%num_prey * data%zoops(zoop_i)%Cmin_grz_zoo ) THEN
          food = zero_
          grazing = food / zoo
+		 ! The next ELSEIF statement compares food (mmC/m3/d) with available prey (mmC/m3)
+		 ! Units missing a factor of time? Or implicit assumption of one day of grazing?
       ELSEIF (food > Ctotal_prey - data%zoops(zoop_i)%num_prey * data%zoops(zoop_i)%Cmin_grz_zoo ) THEN
-         food = Ctotal_prey - data%zoops(zoop_i)%num_prey * data%zoops(zoop_i)%Cmin_grz_zoo
-         grazing = food / zoo
+         food = Ctotal_prey - data%zoops(zoop_i)%num_prey * data%zoops(zoop_i)%Cmin_grz_zoo ! Units: food units have changed from mmC/m3/d to just mmC/m3
+         grazing = food / zoo ! Units: grazing has changed to dimensionless (mmC/m3)/ (mmC/m3)
       ENDIF
-
 
       ! Now determine prey composition based on preference factors and
       ! availability of prey


### PR DESCRIPTION
The units in the food calculations of aed_zooplankton are expanded with some MEB commentary and a possible conflict noted. Specifically, the units of 'food' initially have a /d (time) component but are compared in an IF statement with a pure concentration. In one IF component, 'food' is then set to the same value as the concentration so it looks like 'food' units have changed. This then has flow on effects as 'grazing' is recomputed from the quotient of food and zoo concentration, making 'grazing' effectively dimensionless. Not sure if this is a correct interpretation but the influence of time (/d) seems to have dropped out somewhere, unless there is an implicit assumption of allowing grazing to occur for a day?

I also can see that neither of the IF statements need to be entered - it may well be that the majority of cases do not enter either condition, so 'food' simply remains as grazing * zoo, which is obviously then fine for future calculations.

Similar rate (food) vs concentration (C - c_min) are made later in the code too, so I guess this pull request is a conceptual one around a recurring piece of logic. If the assumption is that the concentration is actually a daily rate (i.e. the concentrations are divided by 1.0) and so the available mass is to be consumed in a day, then I can see how things might work, but am keen to confirm (or not).

The time dimension is listed /d in the code and above - acknowledged it may be /s, but the potential issue above remains.