### PR TITLE
Suggest OGM diag fix

### DIFF
--- a/src/aed_zooplankton.F90
+++ b/src/aed_zooplankton.F90
@@ -548,7 +548,7 @@ SUBROUTINE aed_calculate_zooplankton(data,column,layer_idx)
       grazing_p = zero_
       phy_i = 0
       DO prey_i = 1,data%zoops(zoop_i)%num_prey
-         IF (data%zoops(zoop_i)%prey(prey_i)%zoop_prey .EQ. _OGMPOC_) THEN
+         IF (data%zoops(zoop_i)%prey(prey_i)%zoop_prey(1:3) .EQ. _OGMPOC_) THEN
             IF (poc > zero_) THEN
                 grazing_n = grazing_n + grazing_prey(prey_i) * pon/poc
                 grazing_p = grazing_p + grazing_prey(prey_i) * pop/poc
@@ -664,7 +664,7 @@ SUBROUTINE aed_calculate_zooplankton(data,column,layer_idx)
             _FLUX_VAR_(data%zoops(zoop_i)%id_prey(prey_i)) =                         &
                        _FLUX_VAR_(data%zoops(zoop_i)%id_prey(prey_i)) +              &
                        ( -1.0 * grazing_prey(prey_i))
-            IF (data%zoops(zoop_i)%prey(prey_i)%zoop_prey .EQ. _OGMPOC_) THEN
+            IF (data%zoops(zoop_i)%prey(prey_i)%zoop_prey(1:3) .EQ. _OGMPOC_) THEN
                IF (poc > zero_) THEN
                   _FLUX_VAR_(data%id_Nmorttarget) =     &
                           _FLUX_VAR_(data%id_Nmorttarget) + ( -1.0 * grazing_prey(prey_i) * pon/poc)


### PR DESCRIPTION
The code currently does not enter IF statements for OGM prey constituents because the IF test is on the entire variable name - OGM_poc -  but the defined string _OGMPOC_ to compare with is only the first three characters of the prey var name - OGM. (1:3) added to the string test (first line in code below) , which is the same logic as the existing (correct) phyto string comparison test.

         IF (data%zoops(zoop_i)%prey(prey_i)%zoop_prey(1:3) .EQ. _OGMPOC_) THEN
            IF (poc > zero_) THEN
                grazing_n = grazing_n + grazing_prey(prey_i) * pon/poc
                grazing_p = grazing_p + grazing_prey(prey_i) * pop/poc
            ELSE
                grazing_n = zero_
                grazing_p = zero_
            ENDIF 
         ELSEIF (data%zoops(zoop_i)%prey(prey_i)%zoop_prey(1:_PHYLEN_).EQ. _PHYMOD_) THEN
            phy_i = phy_i + 1
            IF (aed_get_var(data%zoops(zoop_i)%id_prey(prey_i),tvar)) THEN
                ! Simulates internal nutrients
                IF (tvar%supplementary4 == 2) THEN
                    phy_INcon(phy_i) = _STATE_VAR_(data%zoops(zoop_i)%id_phyIN(phy_i))
                    phy_IPcon(phy_i) = _STATE_VAR_(data%zoops(zoop_i)%id_phyIP(phy_i))
                ! Does not simulate internal nutrients
                ELSEIF (tvar%supplementary4 == 0) THEN
                    phy_INcon(phy_i) = prey(phy_i) * tvar%supplementary1
                    phy_IPcon(phy_i) = prey(phy_i) * tvar%supplementary2
                ! Exit - simdynamics 1
                ELSE
                    STOP
                END IF         
            END IF
